### PR TITLE
コントローラーで操作できるようにする #9

### DIFF
--- a/PvP_Shooting/PvP_Shooting/Main.cpp
+++ b/PvP_Shooting/PvP_Shooting/Main.cpp
@@ -29,6 +29,7 @@ int WINAPI WinMain ( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 		// 入力状態を更新
 		if ( UpdateKeyState() != 0 ) break;
 		if ( UpdateMouseButtonState() != 0 ) break;
+		if ( UpdatePadState() != 0 )break;
 
 		SceneBase::CreateScene();
 		SceneBase::ExecuteScene();

--- a/PvP_Shooting/PvP_Shooting/Script/Function.cpp
+++ b/PvP_Shooting/PvP_Shooting/Script/Function.cpp
@@ -7,12 +7,15 @@ InputState keyState[256];
 /// @brief マウスボタンが何フレーム入力されているか保存する
 InputState mouseState[MOUSEBUTTON_UPDATE_RANGE] = {};
 
+/// @brief ボタンが何フレーム入力されているか保存する
+InputState padState[2][8];
+
 bool Fade( FadeMode fademode, unsigned int fadePower, int fadeColor, int waitTime ) {
 
 	const int ALPHA_MAX = 255;
 	const int ALPHA_MIN = 0;
 	const int ALPHA_INVALID = -1;
-	
+
 	static int alpha = ALPHA_INVALID;
 	static int waitTimeCount = 0;
 
@@ -125,6 +128,54 @@ InputState GetMouseButtonStatus( int mouseButtonCode ) {
 
 void MouseButtonInputEnabledToggle( int mouseButtonCode ) {
 	mouseState[mouseButtonCode] = ( mouseState[mouseButtonCode] == InputState::Invalid ) ? InputState::NotPressed : InputState::Invalid;
+}
+
+int UpdatePadState(){
+	char currentPadState[2][8];
+
+	currentPadState[0][0] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_DOWN ) == 0 ) ? 0 : 1;
+	currentPadState[0][1] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_LEFT ) == 0 ) ? 0 : 1;
+	currentPadState[0][2] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_RIGHT ) == 0 ) ? 0 : 1;
+	currentPadState[0][3] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_UP ) == 0 ) ? 0 : 1;
+	currentPadState[0][4] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_1 ) == 0 ) ? 0 : 1;
+	currentPadState[0][5] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_2 ) == 0 ) ? 0 : 1;
+	currentPadState[0][6] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_3 ) == 0 ) ? 0 : 1;
+	currentPadState[0][7] = ( ( GetJoypadInputState( DX_INPUT_PAD1 ) & PAD_INPUT_4 ) == 0 ) ? 0 : 1;
+
+	currentPadState[1][0] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_DOWN ) == 0 ) ? 0 : 1;
+	currentPadState[1][1] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_LEFT ) == 0 ) ? 0 : 1;
+	currentPadState[1][2] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_RIGHT ) == 0 ) ? 0 : 1;
+	currentPadState[1][3] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_UP ) == 0 ) ? 0 : 1;
+	currentPadState[1][4] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_1 ) == 0 ) ? 0 : 1;
+	currentPadState[1][5] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_2 ) == 0 ) ? 0 : 1;
+	currentPadState[1][6] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_3 ) == 0 ) ? 0 : 1;
+	currentPadState[1][7] = ( ( GetJoypadInputState( DX_INPUT_PAD2 ) & PAD_INPUT_4 ) == 0 ) ? 0 : 1;
+
+
+	for( int i = 0; i < 8; i++ ){
+		for( int p = 0; p < 2; p++ )padState[p][i] = UpdateInputState( currentPadState[p][i], padState[p][i] );
+	}
+
+	return 0;
+}
+
+InputState GetPadStatus( int padNum, int padCode ){
+
+	int convertedPadCode = -1;
+
+	switch( padCode ){
+	case PAD_INPUT_DOWN:	convertedPadCode = 0; break;
+	case PAD_INPUT_LEFT:	convertedPadCode = 1; break;
+	case PAD_INPUT_RIGHT:	convertedPadCode = 2; break;
+	case PAD_INPUT_UP:		convertedPadCode = 3; break;
+	case PAD_INPUT_1:		convertedPadCode = 4; break;
+	case PAD_INPUT_2:		convertedPadCode = 5; break;
+	case PAD_INPUT_3:		convertedPadCode = 6; break;
+	case PAD_INPUT_4:		convertedPadCode = 7; break;
+	default:break;
+	}
+
+	return padState[padNum - 1][convertedPadCode];
 }
 
 bool IsOutsideWindow( int posX, int posY ){

--- a/PvP_Shooting/PvP_Shooting/Script/Header/Function.h
+++ b/PvP_Shooting/PvP_Shooting/Script/Header/Function.h
@@ -69,6 +69,16 @@ InputState GetMouseButtonStatus( int mouseButtonCode );
 /// @param mouseButtonCode 入力の無効/有効を切り替えたいマウスボタンのコード
 void MouseButtonInputEnabledToggle( int mouseButtonCode );
 
+/// @brief パッドの入力状態を更新する
+/// @return 0以外はエラー
+int UpdatePadState();
+
+/// @brief パッドボタンの入力状態を取得する
+/// @param padNum パッドの識別番号
+/// @param padCode 入力状態を取得したいボタンのコード
+/// @return InputStateで返す
+InputState GetPadStatus( int padNum, int padCode );
+
 /// @brief 対象が画面外にいるか判定する
 /// @param posX 対象のX座標
 /// @param posY 対象のY座標

--- a/PvP_Shooting/PvP_Shooting/Script/Header/Player.h
+++ b/PvP_Shooting/PvP_Shooting/Script/Header/Player.h
@@ -22,15 +22,18 @@ class Player {
 public:
 
 	/// @brief コンストラクタ
-	/// @param playerNum 1か2
+	/// @param isUsePad パッドを使用するか
+	/// @param padNum 使用するコントローラー : キーボードの場合は0
+	/// @param playerNum 個体識別用
 	/// @param keyUp 上移動に使用するキー
 	/// @param keyRight 右移動に使用するキー
 	/// @param keyLeft 左移動に使用するキー
 	/// @param keyDown 下移動に使用するキー
 	/// @param keyShot 射撃に使用するキー
 	/// @param keyBomb 爆弾に使用するキー
+	/// @param keyUlt 必殺技に使用するキー
 	/// @param spritePath 読み込む画像のパス
-	Player( int playerNum, int keyUp, int keyRight, int keyLeft, int keyDown, int keyShot, int keyBomb, LPCTSTR spritePath );
+	Player( bool isUsePad, int padNumber, int playerNum, int keyUp, int keyRight, int keyLeft, int keyDown, int keyShot, int keyBomb, int keyUlt, LPCTSTR spritePath );
 
 	/// @brief デストラクタ
 	~Player();
@@ -120,12 +123,15 @@ private:
 	int chargeCount;
 	int score[3];
 
+	bool usePad;
+	int padNum;
 	int upMovingKey;
 	int rightMovingKey;
 	int leftMovingKey;
 	int downMovingKey;
 	int shotKey;
 	int bombKey;
+	int ultKey;
 	LPCTSTR spriteFolderPath;
 };
 

--- a/PvP_Shooting/PvP_Shooting/Script/Player.cpp
+++ b/PvP_Shooting/PvP_Shooting/Script/Player.cpp
@@ -1,7 +1,9 @@
 ﻿
 #include "Header/Player.h"
 
-Player::Player( int playerNum, int keyUp, int keyRight, int keyLeft, int keyDown, int keyShot, int keyBomb, LPCTSTR spritePath ) {
+#define USE_CONTROLLER
+
+Player::Player( bool isUsePad, int padNumber, int playerNum, int keyUp, int keyRight, int keyLeft, int keyDown, int keyShot, int keyBomb, int keyUlt, LPCTSTR spritePath ){
 	playerNumber = playerNum;
 	isAlive = true;
 	respawnCount = 0;
@@ -13,12 +15,15 @@ Player::Player( int playerNum, int keyUp, int keyRight, int keyLeft, int keyDown
 	chargeCount = 0;
 	for( int i = 0; i < ROUND_MAX; i++ )score[i] = 0;
 
+	usePad = isUsePad;
+	padNum = padNumber;
 	upMovingKey = keyUp;
 	rightMovingKey = keyRight;
 	leftMovingKey = keyLeft;
 	downMovingKey = keyDown;
 	shotKey = keyShot;
 	bombKey = keyBomb;
+	ultKey = keyUlt;
 	spriteFolderPath = spritePath;
 	dir = Direction::Down;
 
@@ -33,6 +38,26 @@ void Player::Move() {
 
 	if( isAlive == false ) return;
 
+#ifdef USE_CONTROLLER
+	if( GetPadStatus( playerNumber, upMovingKey ) == InputState::Pressing ){
+		posY -= speed;
+		dir = Direction::Up;
+	}
+	else if( GetPadStatus( playerNumber, downMovingKey ) == InputState::Pressing ){
+		posY += speed;
+		dir = Direction::Down;
+	}
+
+	if( GetPadStatus( playerNumber, rightMovingKey ) == InputState::Pressing ){
+		posX += speed;
+		dir = Direction::Right;
+	}
+	else if( GetPadStatus( playerNumber, leftMovingKey ) == InputState::Pressing ){
+		posX -= speed;
+		dir = Direction::Left;
+	}
+
+#else
 	if( GetKeyStatus( upMovingKey ) == InputState::Pressing ) {
 		posY -= speed;
 		dir = Direction::Up;
@@ -50,6 +75,7 @@ void Player::Move() {
 		posX -= speed;
 		dir = Direction::Left;
 	}
+#endif
 }
 
 void Player::Draw() {
@@ -75,11 +101,20 @@ void Player::Shoot() {
 		}
 	}
 
+	// 射撃キーが押されたら弾を生成
 	if( shootingCoolTime > SHOOTING_COOL_TIME ){
-		if( GetKeyStatus( shotKey ) == InputState::Pressing ){
+#ifdef USE_CONTROLLER
+		if( GetPadStatus( playerNumber, shotKey ) == InputState::Pressing ){
+#else
+		if( GetKeyStatus( shotKey ) == InputState::Pressed ){
+#endif
 			chargeCount++;
 		}
+#ifdef USE_CONTROLLER
+		else if( GetPadStatus( playerNumber, shotKey ) == InputState::Released ){
+#else
 		else if( GetKeyStatus( shotKey ) == InputState::Released ){
+#endif
 			bool tempCharge = false;
 			if( chargeCount >= CHARGE_COUNT ){
 				tempCharge = true;

--- a/PvP_Shooting/PvP_Shooting/Script/SceneBase.cpp
+++ b/PvP_Shooting/PvP_Shooting/Script/SceneBase.cpp
@@ -10,8 +10,15 @@
 FadeMode SceneBase::fadeMode = FadeMode::None;
 SceneList SceneBase::currentScene = SceneList::Title;
 
-Player* SceneBase::player1 = new Player( 1, KEY_INPUT_UP, KEY_INPUT_RIGHT, KEY_INPUT_LEFT, KEY_INPUT_DOWN, KEY_INPUT_Z, KEY_INPUT_X, spriteList[0] );
-Player* SceneBase::player2 = new Player( 2, KEY_INPUT_W, KEY_INPUT_D, KEY_INPUT_A, KEY_INPUT_S, KEY_INPUT_C, KEY_INPUT_V, spriteList[0] );
+#define USE_CONTROLLER
+#ifdef USE_CONTROLLER
+Player* SceneBase::player1 = new Player( true, DX_INPUT_PAD1, 1, PAD_INPUT_UP, PAD_INPUT_RIGHT, PAD_INPUT_LEFT, PAD_INPUT_DOWN, PAD_INPUT_2, PAD_INPUT_1, PAD_INPUT_4, spriteList[0] );
+Player* SceneBase::player2 = new Player( true, DX_INPUT_PAD2, 2, PAD_INPUT_UP, PAD_INPUT_RIGHT, PAD_INPUT_LEFT, PAD_INPUT_DOWN, PAD_INPUT_2, PAD_INPUT_1, PAD_INPUT_4, spriteList[0] );
+#else
+Player* SceneBase::player1 = new Player( false, 0, 1, KEY_INPUT_UP, KEY_INPUT_RIGHT, KEY_INPUT_LEFT, KEY_INPUT_DOWN, KEY_INPUT_Z, KEY_INPUT_X, spriteList[0] );
+Player* SceneBase::player2 = new Player( false, 0, 2, KEY_INPUT_W, KEY_INPUT_D, KEY_INPUT_A, KEY_INPUT_S, KEY_INPUT_C, KEY_INPUT_V, spriteList[0] );
+#endif
+
 Player* SceneBase::playerList[PLAYER_MAX] {
 	player1,
 	player2


### PR DESCRIPTION
Nintendo Switch の JoyConで操作できるようにする
1P JoyCon(R)
2P JoyCon(L)

アナログスティックで移動（８方向）
A(右)ボタンで射撃
B(下)ボタンで爆弾(爆弾ない)
X(上)ボタンで必殺技(必殺技ない)